### PR TITLE
MAINT: SSL certificate validation deactivated

### DIFF
--- a/dtool_ecs/storagebroker.py
+++ b/dtool_ecs/storagebroker.py
@@ -71,12 +71,14 @@ class ECSStorageBroker(S3StorageBroker):
         self.s3resource = session.resource(
             's3',
             endpoint_url=ecs_endpoint,
-            config=BOTO3_CONFIG
+            config=BOTO3_CONFIG,
+            verify=False,
         )
         self.s3client = session.client(
             's3',
             endpoint_url=ecs_endpoint,
-            config=BOTO3_CONFIG
+            config=BOTO3_CONFIG,
+            verify=False,
         )
 
         self._structure_parameters = _ECS_STRUCTURE_PARAMETERS
@@ -128,7 +130,8 @@ class ECSStorageBroker(S3StorageBroker):
         resource = session.resource(
             's3',
             endpoint_url=ecs_endpoint,
-            config=BOTO3_CONFIG
+            config=BOTO3_CONFIG,
+            verify=False,
         )
 
         parse_result = generous_parse_uri(base_uri)


### PR DESCRIPTION
Hello Tjelvar, this is not a true pull request but rather a note. In certain circumstances it might be useful to suppress SSL certificate checking on the client's side, i.e. for testing purposes in general or in case a safe connection through an SSH tunnel exists. I first thought I might be able to do this via some boto3 config file or environment variable, but did not find anything suitable documented onhttps://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html. 